### PR TITLE
Also build fonts without Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ enable_testing()
 
 find_package(
     PythonModules
-    REQUIRED COMPONENTS fontTools fontTools.ttx brotli)
+    COMPONENTS fontTools fontTools.ttx brotli)
 
 find_package(
     Qt6

--- a/cmake/IconFonts.cmake
+++ b/cmake/IconFonts.cmake
@@ -11,6 +11,7 @@ include(IconFontsUtilities)
 function(iconfonts_add_font)
     set(options
         OPTIONAL                # the option for enabling this font is disabled by default for OPTIONAL fonts
+        PYTHON_REQUIRED         # skip and warn if no Python interpreter is available
         SKIP_RESOURCES)         # do not generate Qt resources
 
     set(mandatory_values
@@ -39,6 +40,11 @@ function(iconfonts_add_font)
 
     iconfonts_reject_unparsed_arguments(ICONFONTS)
     iconfonts_require_mandatory_arguments(ICONFONTS ${mandatory_values})
+
+    if (ICONFONTS_PYTHON_REQUIRED AND NOT TARGET Python3::Interpreter)
+        message(WARNING "Skipping ${ICONFONTS_FONT_FAMILY}  ${ICONFONTS_FONT_VARIANT} because no Python interpreter was not found")
+        return()
+    endif()
 
     if (ICONFONTS_OPTIONAL)
         set(ICONFONTS_DEFAULT_VALUE OFF)
@@ -234,7 +240,8 @@ endfunction(iconfonts_add_font)
 # FIXME doxs
 function(iconfonts_add_font_family)
     set(options
-        OPTIONAL)               # the option for enabling this font is disabled by default for OPTIONAL fonts
+        OPTIONAL                # the option for enabling this font is disabled by default for OPTIONAL fonts
+        PYTHON_REQUIRED)        # skip and warn if no Python interpreter is available
 
     set(mandatory_values
         TARGET                  # the target to which to add this font variant
@@ -261,10 +268,14 @@ function(iconfonts_add_font_family)
     iconfonts_require_mandatory_arguments(ICONFONTS ${mandatory_values} FONT_VARIANTS)
     iconfonts_unescape(ICONFONTS_VARIANT_PATTERN)
 
+    set(extra_options)
+
     if (ICONFONTS_OPTIONAL)
-        set(ICONFONTS_OPTIONAL "OPTIONAL")
-    else()
-        unset(ICONFONTS_OPTIONAL)
+        list(APPEND extra_options "OPTIONAL")
+    endif()
+
+    if (ICONFONTS_PYTHON_REQUIRED)
+        list(APPEND extra_options "PYTHON_REQUIRED")
     endif()
 
     unset(combined_resources_list) # ------------------------------------------------------------- collect font variants
@@ -306,7 +317,7 @@ function(iconfonts_add_font_family)
         iconfonts_add_font(
             TARGET                  "${ICONFONTS_TARGET}"
             QUICK_TARGET            "${ICONFONTS_QUICK_TARGET}"
-                                    "${ICONFONTS_OPTIONAL}"
+                                    "${extra_options}"
             SKIP_RESOURCES                                          # must collect resources for all variants here
 
             BASE_URL                "${ICONFONTS_BASE_URL}"

--- a/cmake/IconFontsParser.cmake
+++ b/cmake/IconFontsParser.cmake
@@ -237,6 +237,7 @@ function(__iconfonts_collect_icons_materialsymbols OUTPUT_VARIABLE INFO_FILEPATH
         __iconfonts_collect_icons_python("${OUTPUT_VARIABLE}" "${INFO_FILEPATH}")
     else()
         file(STRINGS "${INFO_FILEPATH}" codepoint_list)
+        set(name_list)
 
         foreach(codepoint IN LISTS codepoint_list)
             string(REGEX REPLACE " +" ";" codepoint "${codepoint}")
@@ -245,7 +246,33 @@ function(__iconfonts_collect_icons_materialsymbols OUTPUT_VARIABLE INFO_FILEPATH
             list(GET codepoint 1 unicode)
 
             __iconfonts_make_symbol("${name}" name)
+
+            if (name IN_LIST name_list) # --------------------------------- find alternate name for confliciting symbols
+                message(STATUS "Searching alternate name for ${name}...")
+
+                foreach(i RANGE 0 999)
+                    if (i GREATER 0)
+                        set(alt_name "${name}Alt${i}")
+                    else()
+                        set(alt_name "${name}Alt")
+                    endif()
+
+                    if (NOT alt_name IN_LIST name_list)
+                        set(name "${alt_name}")
+                        unset(alt_name)
+                        break()
+                    endif()
+                endforeach()
+
+                if (alt_name)
+                    message(FATAL_ERROR "Could not find alternate name for ${name}")
+                    return()
+                endif()
+            endif()
+
             __iconfonts_add_enumkey(icon_definitions "${name}" "0x${unicode}")
+
+            list(APPEND name_list "${name}")
         endforeach()
     endif()
 

--- a/cmake/IconFontsUtilities.cmake
+++ b/cmake/IconFontsUtilities.cmake
@@ -113,6 +113,11 @@ endfunction()
 # ----------------------------------------------------------------------------------------------------------------------
 function(__iconfonts_convert_webfont FONT_FILEPATH OUTPUT_DIRECTORY OUTPUT_VARIABLE)
     if (FONT_FILEPATH MATCHES "\\.woff")
+        if (NOT Python3::Interpreter)
+            message(FATAL_ERROR "A Python interpreter is needed to convert webfonts")
+            return()
+        endif()
+
         cmake_path(GET FONT_FILEPATH STEM basename)
 
         set(fonttool_filepath "${OUTPUT_DIRECTORY}/${basename}.ttx")

--- a/iconfonts/CMakeLists.txt
+++ b/iconfonts/CMakeLists.txt
@@ -90,6 +90,7 @@ iconfonts_add_font(
     FONT_FAMILY "Bootstrap"
     QUICK_TARGET QuickIconFonts
     TARGET IconFonts
+    PYTHON_REQUIRED
 
     BASE_URL            "https://github.com/twbs/icons@v1.11.3"
     RESOURCE_PREFIX     "/bootstrap/icons"
@@ -269,6 +270,7 @@ iconfonts_add_font(
     FONT_FAMILY "IcoMoon Free"
     QUICK_TARGET QuickIconFonts
     TARGET IconFonts
+    PYTHON_REQUIRED
 
     BASE_URL            "https://github.com/Keyamoon/IcoMoon-Free@d006795ede82361e1bac1ee76f215cf1dc51e4ca"
     RESOURCE_PREFIX     "/icomoon/free"


### PR DESCRIPTION
Having Python around greatly helps to build icon fonts, but let's keep it optional.